### PR TITLE
Fix encoding buffer to support browsers

### DIFF
--- a/src/encoder.js
+++ b/src/encoder.js
@@ -8,7 +8,7 @@ const buildEncoder = (options = {}) => {
 
         encode(packet) {
             const encoded = msgpack.encode(packet, this.options);
-            const buffer = Buffer.from(encoded);
+            const buffer = new Uint8Array(encoded);
 
             return [buffer];
         }


### PR DESCRIPTION
Normally msgpack-javascript should work out of the box as the output of encode is Uint8array but due to this issue we have to initialise it again as the buffer is missing Ref https://github.com/msgpack/msgpack-javascript/issues/145

Fixes #7 