### PR TITLE
Include ES module in npm package when published

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skgdev/socket.io-msgpack-javascript",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@skgdev/socket.io-msgpack-javascript",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skgdev/socket.io-msgpack-javascript",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "socket.io parser based on msgpack",
   "main": "dist/index.cjs",
   "module": "dist/index.module.js",
@@ -11,8 +11,8 @@
     "lodash": "4.17.21"
   },
   "scripts": {
-    "build": "rimraf dist && rollup -c --bundleConfigAsCjs",
-    "watch": "rollup -c -w --bundleConfigAsCjs",
+    "build": "rimraf dist && rollup -c",
+    "watch": "rollup -c -w",
     "prepare": "npm run build",
     "test": "mocha --bail test/index.js",
     "coverage": "nyc mocha test && open coverage/lcov-report/index.html"
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/skgdev/socket.io-msgpack-javascript#readme",
   "files": [
-    "index.js",
-    "/src"
+    "dist/index.cjs",
+    "dist/index.module.js"
   ],
   "devDependencies": {
     "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "homepage": "https://github.com/skgdev/socket.io-msgpack-javascript#readme",
   "files": [
-    "dist/index.cjs",
-    "dist/index.module.js"
+    "dist"
   ],
   "devDependencies": {
     "@babel/core": "7.21.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,9 @@
 import babel from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import pkg from './package.json';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('package.json', { encoding: 'utf8' }));
 
 export default {
     input: './index.js',


### PR DESCRIPTION
This PR introduces **1.2.1** version which includes minor updates.
The rollup bundling configuration was added in a previous version, but the corresponding updates to the "files" property of package.json were not made. Thus the ES module is excluded from the npm package when used by consumers. Moreover, the `bundleConfigAsCjs` option is not needed anymore as we import the package.json by directly reading the file from the filesystem and then parsing it.
